### PR TITLE
Add GitHub Skills activity to signup page

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills using GitHub, as part of the GitHub Certifications program",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 30,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the missing **GitHub Skills** activity to the school's extracurricular activities signup page.

## Issue

Resolves #6 — A student reported that the GitHub Skills activity, announced by the principal at a school assembly as part of a new partnership with GitHub, was not available for registration. Registrations are time-sensitive (closing end of this week) and the activity is the first part of the GitHub Certifications program.

## Changes

- Added "GitHub Skills" entry to the in-memory `activities` dictionary in `src/app.py`
  - Description highlights coding, collaboration, and the GitHub Certifications program
  - Schedule: Mondays and Wednesdays, 3:30 PM - 4:30 PM
  - Max participants: 30 (to accommodate high demand)
